### PR TITLE
Create generic block components

### DIFF
--- a/src/components/BlockQuote/BlockQuote.tsx
+++ b/src/components/BlockQuote/BlockQuote.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import type {TextNode} from '@nebuloid-types/text-node'
+
+type HTMLBlockQuoteProps = JSX.IntrinsicElements['blockquote']
+type HTMLFigureProps = JSX.IntrinsicElements['figure']
+
+interface Props extends HTMLFigureProps, Pick<HTMLBlockQuoteProps, 'cite'> {
+	children: TextNode,
+	author?: TextNode,
+}
+
+const BlockQuote: React.FC<Props> = ({
+	children: quotation,
+	author,
+	cite,
+	...props
+}) => (
+	<figure {...props}>
+		<blockquote cite={cite}>
+			{quotation}
+		</blockquote>
+
+		{author != null && (
+			<figcaption>
+				{author}
+			</figcaption>
+		)}
+	</figure>
+)
+
+export {BlockQuote}

--- a/src/components/BlockQuote/BlockQuote.tsx
+++ b/src/components/BlockQuote/BlockQuote.tsx
@@ -9,6 +9,18 @@ interface Props extends HTMLFigureProps, Pick<HTMLBlockQuoteProps, 'cite'> {
 	author?: TextNode,
 }
 
+/* / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+Block Quote
+-----------
+This component creates a blockquote by leveraging certain
+ HTML5 components like figure, figcaption, and blockquote.
+While this could have been done with regular markup, having
+ a well-defined component makes certain tasks easier.
+For example, styling and type-checking is more modularized.
+
+When using this component, consider using
+ the <cite> and <mark> elements for further markup.
+/ / / / / / / / / / / / / / / / / / / / / / / / / / / / / */
 const BlockQuote: React.FC<Props> = ({
 	children: quotation,
 	author,

--- a/src/components/BlockQuote/index.ts
+++ b/src/components/BlockQuote/index.ts
@@ -1,0 +1,1 @@
+export {BlockQuote} from './BlockQuote'

--- a/src/components/BulletedList/BulletedList.tsx
+++ b/src/components/BulletedList/BulletedList.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import type {TextNode} from '@nebuloid-types/text-node'
+
+type ListNode = TextNode | Array<TextNode>
+
+interface BaseProps {
+	items: Array<ListNode>,
+}
+
+type HTMLUnorderedListProps = JSX.IntrinsicElements['ul']
+type HTMLOrderedListProps = JSX.IntrinsicElements['ol']
+
+type Props = BaseProps & (
+	| (HTMLUnorderedListProps & {as: 'ul'})
+	| (HTMLOrderedListProps & {as: 'ol'})
+)
+
+const BulletedList: React.FC<Props> = ({
+	as: ListElement,
+	items,
+	...props
+}) => (
+	<ListElement
+		// WARNING!
+		// There is a problem that I am encountering with
+		//  Polymorphic Components and Discrimitory Unions,
+		//  relating to extending Base HTML Attributes.
+		// Point is, we shouldn't need to assert this type!
+		//
+		// TODO!
+		// Resolve and delete the type assertion below.
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		{...props as Record<string, unknown>}
+	>
+		{items.map((item, index) => (
+			<li key={index}>
+				{item}
+			</li>
+		))}
+	</ListElement>
+)
+
+export {BulletedList}

--- a/src/components/BulletedList/BulletedList.tsx
+++ b/src/components/BulletedList/BulletedList.tsx
@@ -15,6 +15,16 @@ type Props = BaseProps & (
 	| (HTMLOrderedListProps & {as: 'ol'})
 )
 
+/* / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+Bulleted List
+-------------
+This component generates an ordered or unordered list.
+It leverages the ul, ol, and li elements, and adds some
+ additional type-checking for its children nodes.
+The component is structured for modularized styling as well.
+Be aware that it is specifically meant for block text,
+ and not for sectioning elements like navbars.
+/ / / / / / / / / / / / / / / / / / / / / / / / / / / / / */
 const BulletedList: React.FC<Props> = ({
 	as: ListElement,
 	items,

--- a/src/components/BulletedList/index.ts
+++ b/src/components/BulletedList/index.ts
@@ -1,0 +1,1 @@
+export {BulletedList} from './BulletedList'

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import styles from './button.module.scss'
+
+type ButtonSize =
+	| 'small'
+	| 'medium'
+	| 'large'
+
+type ButtonPriority =
+	| 'primary'
+	| 'secondary'
+	| 'tertiary'
+
+interface BaseProps {
+	size?: ButtonSize,
+	priority?: ButtonPriority,
+}
+
+type HTMLAnchorProps = JSX.IntrinsicElements['a']
+type HTMLButtonProps = JSX.IntrinsicElements['button']
+
+type Props = BaseProps & (
+	| (HTMLAnchorProps & {as: 'a'})
+	| (HTMLButtonProps & {as: 'button'})
+)
+
+const Button: React.FC<Props> = ({
+	as: Component,
+	size = 'medium',
+	priority = 'primary',
+	className,
+	...props
+}) => {
+	// Stitch each className together into a single string...
+	const classNames
+	= `${className ?? ''} ${styles.button} ${styles[size]} ${styles[priority]}`
+
+	return (
+		<Component
+			className={classNames}
+
+			// WARNING!
+			// There is a problem that I am encountering with
+			//  Polymorphic Components and Discrimitory Unions,
+			//  relating to extending Base HTML Attributes.
+			// Point is, we shouldn't need to assert this type!
+			//
+			// TODO!
+			// Resolve and delete the type assertion below.
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+			{...props as Record<string, unknown>}
+		>
+			{props.children}
+		</Component>
+	)
+}
+
+export {Button}
+export type {
+	ButtonSize,
+	ButtonPriority,
+}

--- a/src/components/Button/button.module.scss
+++ b/src/components/Button/button.module.scss
@@ -1,0 +1,39 @@
+@use '@styles/placeholders.scss';
+
+.button {
+	@extend %flex-column;
+}
+
+.large {
+	min-height: 4rem;
+	font-size: 1.25em;
+}
+.medium {
+	min-height: 3rem;
+	font-size: 1em;
+}
+.small {
+	min-height: 2rem;
+	font-size: 0.75em
+}
+
+.primary {
+	color: rgb(var(--background-shade));
+	background-color: var(--foreground-color);
+	padding: 0.5em 1em;
+}
+.secondary {
+	color: rgb(var(--foreground-color));
+	background-color: transparent;
+	padding: 0.25em 0.75em;
+
+	border-style: solid;
+	border-width: 0.25rem;
+	border-color: rgb(var(--foregroun-shade));
+
+}
+.tertiary {
+	color: rgb(var(--foreground-color));
+	background-color: transparent;
+	padding: 0.5em 1em;
+}

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export {Button} from './Button'

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -14,6 +14,23 @@ type Props =
 	}
 )
 
+/* / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+Code Block
+----------
+This component leverages base HTML5 elements to create
+ a well-defined system for marking up code blocks.
+The code has an extension and/or or filename prop,
+ which could help with colorization later, if desired.
+
+FUTURE!
+Consider markup with certain other elements,
+ like <mark>, <ins>, and <del>.
+
+FUTURE!
+Maybe colorization would be an easy-ish implementation,
+ if we leveraged an external npm library?
+
+/ / / / / / / / / / / / / / / / / / / / / / / / / / / / / */
 const CodeBlock: React.FC<Props> = ({
 	children,
 	filename,

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import type {TextNode} from '@nebuloid-types/text-node'
+
+type Props =
+& {children: TextNode}
+& (
+	| {
+		filename: string,
+		filetype?: string,
+	}
+	| {
+		filename?: undefined,
+		filetype: string,
+	}
+)
+
+const CodeBlock: React.FC<Props> = ({
+	children,
+	filename,
+	filetype,
+}) => (
+	<figure>
+		{(filetype != null || filename != null) && (
+			<figcaption>
+				{filename != null ? filename : filetype}
+			</figcaption>
+		)}
+
+		<pre>
+			<code>
+				{children}
+			</code>
+		</pre>
+	</figure>
+)
+
+
+export {CodeBlock}

--- a/src/components/CodeBlock/index.ts
+++ b/src/components/CodeBlock/index.ts
@@ -1,0 +1,1 @@
+export {CodeBlock} from './CodeBlock'

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import type {TextNode} from '@nebuloid-types/text-node'
+
+type DefinitionNode = TextNode | Array<TextNode>
+type HTMLDefinitionListProps = JSX.IntrinsicElements['dl']
+
+interface Props extends HTMLDefinitionListProps {
+	items: Array<[
+		// Terms are inline, and are not wrapped in a <p> tag.
+		// They do get wrapped in a block-oriented <dd> though.
+		// There can be one or more synonyms for a term or word,
+		//  so there can be multiple terms for a single idea.
+		terms: TextNode | Array<TextNode>,
+
+		// Definitions are a collection of one or more <p> tags.
+		// There can be one or more paragraphs for a definition,
+		//  and there can be one or more definitions for a term.
+		definitions: DefinitionNode | Array<DefinitionNode>,
+	]>,
+}
+
+const getTermsJSX = (
+	terms: TextNode | Array<TextNode>,
+) => {
+	// There can be one or many synonyms for a specific term.
+	terms = Array.isArray(terms) ? terms : [terms]
+	return terms.map((term) => (
+		<dt>{term}</dt>
+	))
+}
+
+const getDefinitionsJSX = (
+	definitions: DefinitionNode | Array<DefinitionNode>,
+) => {
+	// There can be one or many definitions for a specific term.
+	definitions = Array.isArray(definitions) ? definitions : [definitions]
+	return definitions.map((definition) => (
+		<dd>{definition}</dd>
+	))
+}
+
+const DefinitionList: React.FC<Props> = ({
+	items,
+}) => (
+	<dl>
+		{items.map(([terms, definitions], index) => (
+			// NOTE:
+			// Each definition group can have one or more terms,
+			//  which get defined by one or more definitions.
+			//
+			// There can be several different synonyms for a
+			//  single word or term.
+			// Likewise, there can be several different meanings
+			//  for a single word or term.
+			//
+			// There isn't a specific definition group element,
+			//  so you will notice that a <div> is used here.
+			<div key={index}>
+				{getTermsJSX(terms)}
+				{getDefinitionsJSX(definitions)}
+			</div>
+		))}
+	</dl>
+)
+
+export {DefinitionList}

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -19,6 +19,7 @@ interface Props extends HTMLDefinitionListProps {
 	]>,
 }
 
+/* This function presses given "terms" into JSX. */
 const getTermsJSX = (
 	terms: TextNode | Array<TextNode>,
 ) => {
@@ -29,6 +30,7 @@ const getTermsJSX = (
 	))
 }
 
+/* This function presses given "definitions" into JSX. */
 const getDefinitionsJSX = (
 	definitions: DefinitionNode | Array<DefinitionNode>,
 ) => {
@@ -39,6 +41,25 @@ const getDefinitionsJSX = (
 	))
 }
 
+/* / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+Definition List
+---------------
+This component might seem confusing at first.
+However, it merely emulates the behavior of
+ the <dl> element, with some additional benefits.
+The structure is very well-defined here, which makes things
+ like type-checking and styling easier for consumers.
+For example, it puts groups of <dd>/<dt> pairings
+ into <div>'s for easier styling.
+
+WARNING!
+The current naive implementation of this component may be
+ a bit slow, and could cause excessive re-renders.
+
+TODO!
+To fix this issue, use react state and hooks to help.
+It may also be pertinent to fix the div keys for this, too.
+/ / / / / / / / / / / / / / / / / / / / / / / / / / / / / */
 const DefinitionList: React.FC<Props> = ({
 	items,
 }) => (

--- a/src/components/DefinitionList/index.ts
+++ b/src/components/DefinitionList/index.ts
@@ -1,0 +1,1 @@
+export {DefinitionList} from './DefinitionList'

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -10,6 +10,23 @@ interface Props extends HTMLHeadingGroupProps {
 	level?: number,
 }
 
+/* / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+Dynamic Heading
+---------------
+You may wonder how a heading component could be useful.
+The standard <h1>-through-<h6> elements should do wonders?
+Well that's true, but sometimes you want to one-up the
+ current heading level, without being stuck.
+If your component used an <h3>, but you needed an <h4>,
+ then this Dynamic Heading would have come in handy.
+This also allows for a subheading more easily, grouping
+ a <p>-tag up with an <hgroup>-tag.
+
+FUTURE!
+Using aria-roles, it actually is possible for this component
+ to generate h7's and beyond, by manipulating <p> tags.
+However, its not entirely clear how helpful this would be.
+/ / / / / / / / / / / / / / / / / / / / / / / / / / / / / */
 const Heading: React.FC<Props> = ({
 	children: heading,
 	subheading,

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import type {TextNode} from '@nebuloid-types/text-node'
+
+type HeadingElementType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p'
+type HTMLHeadingGroupProps = JSX.IntrinsicElements['hgroup']
+
+interface Props extends HTMLHeadingGroupProps {
+	children: TextNode,
+	subheading?: TextNode,
+	level?: number,
+}
+
+const Heading: React.FC<Props> = ({
+	children: heading,
+	subheading,
+	level = 1,
+	...rest
+}) => {
+	// Step 1: Generate a heading from the level.
+	let DynamicHeading: HeadingElementType
+	if (level === 1) {
+		DynamicHeading = 'h1'
+	}
+	else if (level === 2) {
+		DynamicHeading = 'h2'
+	}
+	else if (level === 3) {
+		DynamicHeading = 'h3'
+	}
+	else if (level === 4) {
+		DynamicHeading = 'h4'
+	}
+	else if (level === 5) {
+		DynamicHeading = 'h5'
+	}
+	else if (level === 6) {
+		DynamicHeading = 'h6'
+	}
+	else if (level < 1) {
+		throw new Error(
+			'The Heading component can\'t generate headings less than <h1>!',
+		)
+	}
+	else if (level > 6) {
+		throw new Error(
+			'The Heading component can\'t generate headings greater than <h6>!',
+		)
+	}
+	else {
+		throw new Error(
+			'The Heading component can\'t generate fractional-level headings!',
+		)
+	}
+
+	// Step 2: Compile JSX and return.
+	return (
+		<hgroup {...rest}>
+			<DynamicHeading>
+				{heading}
+			</DynamicHeading>
+			{subheading != null && (
+				<p>
+					{subheading}
+				</p>
+			)}
+		</hgroup>
+	)
+}
+
+export {Heading}

--- a/src/components/Heading/index.ts
+++ b/src/components/Heading/index.ts
@@ -1,0 +1,1 @@
+export {Heading} from './Heading'

--- a/src/components/PageWrapper/PageWrapper.tsx
+++ b/src/components/PageWrapper/PageWrapper.tsx
@@ -3,12 +3,14 @@ import {Footer} from './Footer'
 import {Header} from './Header'
 import {SiteLogo} from './SiteLogo'
 import styles from './page-wrapper.module.scss'
+import {Heading} from '@components/Heading'
+import type {TextNode} from '@nebuloid-types/text-node'
 
 type Props = {
 	children: React.ReactNode,
 } & ({
-	heading: React.ReactNode,
-	subheading?: React.ReactNode,
+	heading: TextNode,
+	subheading?: TextNode,
 } | {
 	heading?: undefined,
 	subheading?: undefined,
@@ -36,10 +38,9 @@ const PageWrapper: React.FC<Props> = ({
 			*/}
 			<header className={styles.intro}>
 				{hero && (
-					<hgroup>
-						<h1>{heading}</h1>
-						<p>{subheading}</p>
-					</hgroup>
+					<Heading subheading={subheading}>
+						{heading}
+					</Heading>
 				)}
 
 				<div className={styles['floating-logo']}>

--- a/src/types/text-node.d.ts
+++ b/src/types/text-node.d.ts
@@ -1,0 +1,19 @@
+import type React from 'react'
+
+// TextNode is the type of this component's children.
+// This can be one of multiple things, including:
+// (a) a simple string: "Hello world!"
+// (b) a text-based react fragment: <>Hello world!</>
+//
+// There can be other markup in (b), such as:
+//  <>Hello world! I am <em>Nolan Kovacik</em>.</>
+//
+// WARNING!
+// This is a pretty good type for now, but it allows for
+//  certain other weird children, like certain elements.
+// For example, consider that a <div> tag child is allowed.
+// TODO!
+// Refine this type accordingly.
+type TextNode = string | React.ReactElement
+
+export type {TextNode}


### PR DESCRIPTION
These components will help slot in certain web and blog components in a more structured way. This includes:
- Buttons
- Headings (*not to be confused with Headers*)
- Bulleted Lists
- Definition Lists
- Block Quotes
- Code Blocks

I've also added a `TextNode` type, which can be either a string, or text with inline markup.